### PR TITLE
Restructuring exports to avoid default key

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This module provides the node [url](http://nodejs.org/api/url.html) api layer over the `whatwg-url` class.
 
-**1.45 KB Gzipped**.
+**~1.6 KB Gzipped**.
 
 Works both on the server and client.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-url",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Brings the node url api layer to whatwg-url class",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -14,15 +14,6 @@
  * limitations under the License.
  */
 
-import parse from './parse';
-import format from './format';
-import resolve from './resolve';
-
-export default {
-  parse,
-  format,
-  resolve,
-  resolveObject(fromUrl, toUrl) {
-    return parse(resolve(fromUrl, toUrl));
-  }
-};
+export { default as parse } from './parse';
+export { default as format } from './format';
+export { resolve, resolveObject } from './resolve';

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -21,7 +21,7 @@ import { BASE_URL, PROTOCOL, HOST } from './constants';
 const resolveProtocolRegex = /^([a-z0-9.+-]*:\/\/\/)([a-z0-9.+-]:\/*)?/i;
 const slashedProtocols = /https?|ftp|gopher|file/;
 
-export default function(fromUrl, toUrl) {
+export function resolve(fromUrl, toUrl) {
   let parsedFrom = typeof fromUrl === 'string' ? parse(fromUrl) : fromUrl;
   fromUrl = typeof fromUrl === 'object' ? format(fromUrl) : fromUrl;
   let parsedTo = parse(toUrl);
@@ -77,4 +77,8 @@ export default function(fromUrl, toUrl) {
   }
 
   return resolved;
+}
+
+export function resolveObject(fromUrl, toUrl) {
+  return parse(resolve(fromUrl, toUrl));
 }

--- a/third_party/index.test.js
+++ b/third_party/index.test.js
@@ -21,11 +21,6 @@
 
 let url = require('../dist');
 
-// For karmatic
-if (url.hasOwnProperty('default')) {
-  url = url.default;
-}
-
 // URLs to parse, and expected data
 // { url : parsed }
 const parseTests = {


### PR DESCRIPTION


- [x] Tests pass
- [x] Appropriate changes to README are included in PR
