### PR TITLE
Fix IE11 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-url",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Brings the node url api layer to whatwg-url class",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/src/parse.js
+++ b/src/parse.js
@@ -120,8 +120,8 @@ export default function(urlStr, parseQs = false, slashesDenoteHost = false) {
   }
 
   res.slashes = slashes && !preSlash;
-  res.host = url.host.includes(HOST) ? '' : url.host;
-  res.hostname = url.hostname.includes(HOST)
+  res.host = ~url.host.indexOf(HOST) ? '' : url.host;
+  res.hostname = ~url.hostname.indexOf(HOST)
     ? ''
     : url.hostname.replace(/(\[|\])/g, '');
   res.protocol = err ? protocolPrefix || null : url.protocol;
@@ -132,7 +132,7 @@ export default function(urlStr, parseQs = false, slashesDenoteHost = false) {
   const hashSplit = urlStr.split('#');
   // Handle case when there is a lone '?' in url
   // Eg: http://example.com/?
-  if (!res.search && hashSplit[0].includes('?')) {
+  if (!res.search && ~hashSplit[0].indexOf('?')) {
     res.search = '?';
   }
   // Similarly handle lone '#' Eg: http://example.com/#
@@ -184,7 +184,7 @@ export default function(urlStr, parseQs = false, slashesDenoteHost = false) {
 
   const excludedKeys = /^(file)/.test(res.href) ? ['host', 'hostname'] : [];
   Object.keys(res).forEach(k => {
-    if (!excludedKeys.includes(k)) res[k] = res[k] || null;
+    if (!~excludedKeys.indexOf(k)) res[k] = res[k] || null;
   });
 
   return res;

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -63,7 +63,7 @@ export function resolve(fromUrl, toUrl) {
   // Remove unwanted trailing slash
   if (
     !slashedProtocols.test(resolved) &&
-    !toUrl.includes('.') &&
+    !~toUrl.indexOf('.') &&
     fromUrl.slice(-1) !== '/' &&
     toUrl.slice(-1) !== '/' &&
     resolved.slice(-1) === '/'


### PR DESCRIPTION
`String.includes` & `Array.includes` are not supported in IE11. Replacing them with `indexOf`


- [x] Tests pass
- [x] Appropriate changes to README are included in PR
