### PR TITLE
Removing non standard protocol from constants. Rewrite logic to work …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-url",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Brings the node url api layer to whatwg-url class",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-export const PROTOCOL = 'xyz://';
-export const PARSE_PROTOCOL = 'http://';
+export const PROTOCOL = 'http://';
 export const HOST = 'w.w';
 export const BASE_URL = PROTOCOL + HOST;
-export const PARSE_BASE_URL = PARSE_PROTOCOL + HOST;

--- a/src/parse.js
+++ b/src/parse.js
@@ -16,7 +16,7 @@
 
 import qs from 'querystring';
 import format from './format';
-import { PARSE_BASE_URL, HOST } from './constants';
+import { BASE_URL, HOST } from './constants';
 
 const slashedProtocols = /^https?|ftp|gopher|file/;
 const urlRegex = /^(.+?)([#?].*)/;
@@ -109,7 +109,7 @@ export default function(urlStr, parseQs = false, slashesDenoteHost = false) {
     }
 
     try {
-      url = new URL(urlStr, PARSE_BASE_URL);
+      url = new URL(urlStr, BASE_URL);
     } catch (_) {
       // Unable to parse the url
       // If the URL has only the protocol - Eg: "foo:"

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -57,8 +57,16 @@ export function resolve(fromUrl, toUrl) {
   const normalizedFromUrl = new URL(fromUrl, BASE_URL + '/');
   let resolved = new URL(toUrl, normalizedFromUrl)
     .toString()
-    .replace(PROTOCOL, '')
-    .replace(HOST, '');
+    .replace(BASE_URL, '');
+
+  // Remove/replace the protocol if the URL class has added it
+  let actualProtocol = parsedTo.protocol || parsedFrom.protocol;
+  actualProtocol += parsedFrom.slashes || parsedTo.slashes ? '//' : '';
+  if (!prefix && actualProtocol) {
+    resolved = resolved.replace(PROTOCOL, actualProtocol);
+  } else if (prefix) {
+    resolved = resolved.replace(PROTOCOL, '');
+  }
 
   // Remove unwanted trailing slash
   if (


### PR DESCRIPTION
…with http://

Non standard protocol parsing doesn't work well with url-polyfill. Breaks in nomodule browsers




- [x] Tests pass
- [x] Appropriate changes to README are included in PR
