### PR TITLE
Removing @types/node as a peerDep #10

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,0 @@
-export * from 'url';

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "querystring": "^0.2.0"
   },
-  "peerDependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GoogleChromeLabs/native-url.git"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "typings": "index.d.ts",
+  "typings": "third_party/url.d.ts",
   "scripts": {
     "build": "microbundle",
     "test:browser": "karmatic",
@@ -18,9 +18,7 @@
   "dependencies": {
     "querystring": "^0.2.0"
   },
-  "peerDependencies": {
-    "@types/node": ">=8.0.0"
-  },
+  "peerDependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GoogleChromeLabs/native-url.git"

--- a/third_party/url.d.ts
+++ b/third_party/url.d.ts
@@ -1,0 +1,143 @@
+/**
+ * This project is licensed under the MIT license.
+ * Copyrights are respective of each contributor listed at the beginning of each definition file.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+declare module 'url' {
+  import { ParsedUrlQuery, ParsedUrlQueryInput } from 'querystring';
+
+  // Input to `url.format`
+  interface UrlObject {
+    auth?: string | null;
+    hash?: string | null;
+    host?: string | null;
+    hostname?: string | null;
+    href?: string | null;
+    path?: string | null;
+    pathname?: string | null;
+    protocol?: string | null;
+    search?: string | null;
+    slashes?: boolean | null;
+    port?: string | number | null;
+    query?: string | null | ParsedUrlQueryInput;
+  }
+
+  // Output of `url.parse`
+  interface Url {
+    auth: string | null;
+    hash: string | null;
+    host: string | null;
+    hostname: string | null;
+    href: string;
+    path: string | null;
+    pathname: string | null;
+    protocol: string | null;
+    search: string | null;
+    slashes: boolean | null;
+    port: string | null;
+    query: string | null | ParsedUrlQuery;
+  }
+
+  interface UrlWithParsedQuery extends Url {
+    query: ParsedUrlQuery;
+  }
+
+  interface UrlWithStringQuery extends Url {
+    query: string | null;
+  }
+
+  function parse(urlStr: string): UrlWithStringQuery;
+  function parse(
+    urlStr: string,
+    parseQueryString: false | undefined,
+    slashesDenoteHost?: boolean
+  ): UrlWithStringQuery;
+  function parse(
+    urlStr: string,
+    parseQueryString: true,
+    slashesDenoteHost?: boolean
+  ): UrlWithParsedQuery;
+  function parse(
+    urlStr: string,
+    parseQueryString: boolean,
+    slashesDenoteHost?: boolean
+  ): Url;
+
+  function format(URL: URL, options?: URLFormatOptions): string;
+  function format(urlObject: UrlObject | string): string;
+  function resolve(from: string, to: string): string;
+
+  function domainToASCII(domain: string): string;
+  function domainToUnicode(domain: string): string;
+
+  /**
+   * This function ensures the correct decodings of percent-encoded characters as
+   * well as ensuring a cross-platform valid absolute path string.
+   * @param url The file URL string or URL object to convert to a path.
+   */
+  function fileURLToPath(url: string | URL): string;
+
+  /**
+   * This function ensures that path is resolved absolutely, and that the URL
+   * control characters are correctly encoded when converting into a File URL.
+   * @param url The path to convert to a File URL.
+   */
+  function pathToFileURL(url: string): URL;
+
+  interface URLFormatOptions {
+    auth?: boolean;
+    fragment?: boolean;
+    search?: boolean;
+    unicode?: boolean;
+  }
+
+  class URL {
+    constructor(input: string, base?: string | URL);
+    hash: string;
+    host: string;
+    hostname: string;
+    href: string;
+    readonly origin: string;
+    password: string;
+    pathname: string;
+    port: string;
+    protocol: string;
+    search: string;
+    readonly searchParams: URLSearchParams;
+    username: string;
+    toString(): string;
+    toJSON(): string;
+  }
+
+  class URLSearchParams implements Iterable<[string, string]> {
+    constructor(
+      init?:
+        | URLSearchParams
+        | string
+        | { [key: string]: string | string[] | undefined }
+        | Iterable<[string, string]>
+        | Array<[string, string]>
+    );
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    entries(): IterableIterator<[string, string]>;
+    forEach(
+      callback: (value: string, name: string, searchParams: this) => void
+    ): void;
+    get(name: string): string | null;
+    getAll(name: string): string[];
+    has(name: string): boolean;
+    keys(): IterableIterator<string>;
+    set(name: string, value: string): void;
+    sort(): void;
+    toString(): string;
+    values(): IterableIterator<string>;
+    [Symbol.iterator](): IterableIterator<[string, string]>;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,11 +1113,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
   integrity sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==
 
-"@types/node@^12.12.7":
-  version "12.12.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.7.tgz#01e4ea724d9e3bd50d90c11fd5980ba317d8fa11"
-  integrity sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==
-
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
Fixes #10 

Removing `@types/node` as a peerDependency

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
