### PR TITLE
Ensure that URL constructor is globally available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,27 @@
  * limitations under the License.
  */
 
-// Ensure that URL constructor is globally available
-// https://nodejs.org/api/globals.html#globals_url
-if (typeof global === 'object') {
-  global.URL = global.URL || require('url').URL;
+let root;
+if (typeof window !== 'undefined') {
+  root = window;
+} else if (typeof global !== 'undefined') {
+  /**
+   * Ensure that `URL` & `URLSearchParams` constructors are globally available
+   * @see https://nodejs.org/api/globals.html#globals_url
+   * @see https://nodejs.org/api/globals.html#globals_urlsearchparams
+   */
+  const { URL, URLSearchParams } = require('url');
+  global.URL = global.URL || URL;
+  global.URLSearchParams = global.URLSearchParams || URLSearchParams;
+  root = global;
+} else if (typeof self !== 'undefined') {
+  root = self;
+} else {
+  root = this;
 }
 
 export { default as parse } from './parse';
 export { default as format } from './format';
 export { resolve, resolveObject } from './resolve';
+export const { URL } = root;
+export const { URLSearchParams } = root;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+// Ensure that URL constructor is globally available
+// https://nodejs.org/api/globals.html#globals_url
+if (typeof global === 'object') {
+  global.URL = global.URL || require('url').URL;
+}
+
 export { default as parse } from './parse';
 export { default as format } from './format';
 export { resolve, resolveObject } from './resolve';


### PR DESCRIPTION
WHATWG URL API has been implemented since v7 but global `URL` constructor was added later as part of v10 release.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
