### PR TITLE
feat: export whatwg url interface

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,3 +18,5 @@ export { default as parse } from './parse';
 export { default as format } from './format';
 export { resolve, resolveObject } from './resolve';
 export { default as Url } from './url';
+export { URL as URL }
+export { URLSearchParams as URLSearchParams }

--- a/third_party/url.d.ts
+++ b/third_party/url.d.ts
@@ -141,3 +141,5 @@ declare module 'url' {
     [Symbol.iterator](): IterableIterator<[string, string]>;
   }
 }
+
+export {};


### PR DESCRIPTION
Fixes #33 #34

- [x] Tests pass
- [x] ~~Appropriate changes to README are included in PR~~ Not needed as this PR is implementing the same API as Node's

This PR adds exports for WHATWG `URL` and `URLSearchParams` interface.

Upstream changes:
<https://github.com/nodejs/node/commit/4b312387ead4ba11146b28b8ac05ed385919c4af>
<https://github.com/nodejs/node/commit/326e967c6bddd1cfb901f7b12d06f9e3136243c1>